### PR TITLE
Update: Enable NerdTree's default window switching

### DIFF
--- a/filetypes.vim
+++ b/filetypes.vim
@@ -2,3 +2,4 @@
 au BufNewFile,BufRead *.vue,*.jsx set filetype=html sw=2 ts=2 sts=2
 au BufNewFile,BufRead *.html,*.xml,*.cpp,*.yml set sw=2 ts=2 sts=2
 au BufNewFile,BufRead *.less,*.sass set filetype=css
+au BufNewFile,BufRead cpanfile set filetype=perl

--- a/mappings.vim
+++ b/mappings.vim
@@ -1,5 +1,3 @@
-map <C-p> :set paste<CR>        " Set paste
-map <C-m> :set mouse=a<CR>      " Don't use mouse by default
 map <Leader>a ggVG              " Select all
 
 vnoremap < <gv                  " Reselect visual block after shift indent
@@ -12,6 +10,3 @@ map <C-Right> :tabn<CR>         " Jump to next tab
 " ------ NERDTree
 map <C-n> :NERDTreeToggle<CR>   " NERDTree toggle
 map <Leader>f :NERDTreeFind<CR> " Jump to NERDTree
-
-" ------ BetterWhiteSpace
-map <C-w> :StripWhitespace<CR>  " Remove any trailing white space

--- a/settings.vim
+++ b/settings.vim
@@ -58,11 +58,6 @@ set noswapfile                      " do not write .swp files
 set nobackup                        " do not write backup files
 set nowritebackup
 
-" mouse - also mapped in `maps.vim`
-if has ("mouse")
-  set mouse=a
-endif
-
 " ------ NERDTree
 let NERDTreeShowHidden = 1                          " Show hidden files
 let NERDTreeIgnore = ['\.DS_Store', '\.git$']       " Do not show these hidden files


### PR DESCRIPTION
- Removed StripWhiteSpace mapping. It had the same mapping as window
  switching.
- Turned off mouse and paste defaults.